### PR TITLE
Implement SQLite persistence

### DIFF
--- a/drizzle.config.ts
+++ b/drizzle.config.ts
@@ -1,14 +1,10 @@
-import { defineConfig } from "drizzle-kit";
+import type { Config } from 'drizzle-kit';
 
-if (!process.env.DATABASE_URL) {
-  throw new Error("DATABASE_URL, ensure the database is provisioned");
-}
-
-export default defineConfig({
-  out: "./migrations",
-  schema: "./shared/schema.ts",
-  dialect: "postgresql",
+export default {
+  schema: './shared/schema.ts',
+  out: './drizzle',
+  driver: 'better-sqlite3',
   dbCredentials: {
-    url: process.env.DATABASE_URL,
+    url: './data/valuebuilder.db',
   },
-});
+} satisfies Config;

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "build": "vite build && esbuild server/index.ts --platform=node --packages=external --bundle --format=esm --outdir=dist",
     "start": "NODE_ENV=production node dist/index.js",
     "check": "tsc",
-    "db:push": "drizzle-kit push"
+    "db:push": "drizzle-kit push:sqlite",
+    "db:studio": "drizzle-kit studio"
   },
   "dependencies": {
     "@hookform/resolvers": "^3.10.0",

--- a/server/db.ts
+++ b/server/db.ts
@@ -1,0 +1,45 @@
+import { drizzle } from 'drizzle-orm/better-sqlite3';
+import Database from 'better-sqlite3';
+import * as schema from '@shared/schema';
+import path from 'path';
+import fs from 'fs';
+
+const dataDir = path.join(process.cwd(), 'data');
+if (!fs.existsSync(dataDir)) {
+  fs.mkdirSync(dataDir, { recursive: true });
+}
+
+const sqlite = new Database(path.join(dataDir, 'valuebuilder.db'));
+export const db = drizzle(sqlite, { schema });
+
+export function initializeDatabase() {
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS assessments (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      session_id TEXT NOT NULL UNIQUE,
+      answers TEXT NOT NULL,
+      current_question INTEGER DEFAULT 0,
+      completed INTEGER DEFAULT 0,
+      total_score INTEGER,
+      category_scores TEXT,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP,
+      updated_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+
+  sqlite.exec(`
+    CREATE TABLE IF NOT EXISTS results (
+      id INTEGER PRIMARY KEY AUTOINCREMENT,
+      assessment_id INTEGER NOT NULL,
+      user_name TEXT NOT NULL,
+      user_email TEXT NOT NULL,
+      company_name TEXT,
+      industry TEXT,
+      overall_score INTEGER NOT NULL,
+      category_breakdown TEXT NOT NULL,
+      created_at DATETIME DEFAULT CURRENT_TIMESTAMP
+    );
+  `);
+
+  console.log('Database initialized successfully');
+}

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -1,29 +1,30 @@
-import { pgTable, text, serial, integer, jsonb, timestamp } from "drizzle-orm/pg-core";
-import { createInsertSchema } from "drizzle-zod";
-import { z } from "zod";
+import { sqliteTable, text, integer, blob } from 'drizzle-orm/sqlite-core';
+import { sql } from 'drizzle-orm';
+import { createInsertSchema } from 'drizzle-zod';
+import { z } from 'zod';
 
-export const assessments = pgTable("assessments", {
-  id: serial("id").primaryKey(),
-  sessionId: text("session_id").notNull(),
-  answers: jsonb("answers").notNull(),
-  currentQuestion: integer("current_question").default(0),
-  completed: integer("completed").default(0), // 0 = in progress, 1 = completed
-  totalScore: integer("total_score"),
-  categoryScores: jsonb("category_scores"),
-  createdAt: timestamp("created_at").defaultNow(),
-  updatedAt: timestamp("updated_at").defaultNow(),
+export const assessments = sqliteTable('assessments', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  sessionId: text('session_id').notNull().unique(),
+  answers: blob('answers', { mode: 'json' }).$type<Record<string, AssessmentAnswer>>().notNull(),
+  currentQuestion: integer('current_question').default(0),
+  completed: integer('completed').default(0),
+  totalScore: integer('total_score'),
+  categoryScores: blob('category_scores', { mode: 'json' }).$type<Record<string, CategoryScore>>(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(strftime('%s','now'))`),
+  updatedAt: integer('updated_at', { mode: 'timestamp' }).notNull().default(sql`(strftime('%s','now'))`),
 });
 
-export const results = pgTable("results", {
-  id: serial("id").primaryKey(),
-  assessmentId: integer("assessment_id").notNull(),
-  userName: text("user_name").notNull(),
-  userEmail: text("user_email").notNull(),
-  companyName: text("company_name"),
-  industry: text("industry"),
-  overallScore: integer("overall_score").notNull(),
-  categoryBreakdown: jsonb("category_breakdown").notNull(),
-  createdAt: timestamp("created_at").defaultNow(),
+export const results = sqliteTable('results', {
+  id: integer('id').primaryKey({ autoIncrement: true }),
+  assessmentId: integer('assessment_id').notNull(),
+  userName: text('user_name').notNull(),
+  userEmail: text('user_email').notNull(),
+  companyName: text('company_name'),
+  industry: text('industry'),
+  overallScore: integer('overall_score').notNull(),
+  categoryBreakdown: blob('category_breakdown', { mode: 'json' }).$type<Record<string, CategoryScore>>().notNull(),
+  createdAt: integer('created_at', { mode: 'timestamp' }).notNull().default(sql`(strftime('%s','now'))`),
 });
 
 export const insertAssessmentSchema = createInsertSchema(assessments).omit({


### PR DESCRIPTION
## Summary
- introduce SQLite database setup with Drizzle
- switch storage layer from in-memory to SQLite
- update schema for SQLite compatibility
- adjust Drizzle config for better-sqlite3
- add database helper scripts

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686d4971e708832c914fa0857a4f9ba0