### PR TITLE
Add PDF report templates and category detail pages

### DIFF
--- a/server/reportTemplates.ts
+++ b/server/reportTemplates.ts
@@ -1,0 +1,171 @@
+export const coreDriverDescriptions = {
+  "Financial Performance": {
+    title: "Financial Performance",
+    subtitle: "Your history of producing revenue and profit combined with the professionalism of your record keeping",
+    description: "A financial acquirer sees buying a business as paying today for a stream of profits in the future, which is why companies are generally bought and sold using a multiple of earnings. But focusing on your multiple is a little bit like a hypertensive person focusing on his or her blood pressure report. To really understand the number, and to move it up or down, you have to understand the calculations.",
+    insights: [
+      "The size of your revenue along with your past and expected profitability",
+      "The professionalism of your financial record keeping",
+      "Your ability to generate consistent cash flow"
+    ]
+  },
+
+  "Growth Potential": {
+    title: "Growth Potential", 
+    subtitle: "Your likelihood to grow your business in the future and at what rate",
+    description: "Acquirers typically pay the most for businesses with the potential to grow. In rare cases, an acquiring company may even buy a business that scores high on Growth Potential but low on other attributes, because the acquirer sees a way to leverage some of its own assets to help the business grow much more quickly than it could under its current owner.",
+    insights: [
+      "Market size and your share of it",
+      "Scalability of your business model",
+      "Innovation capabilities and product development",
+      "Geographic and market expansion opportunities"
+    ]
+  },
+
+  "Switzerland Structure": {
+    title: "The Switzerland Structure",
+    subtitle: "How dependent your business is on any one employee, customer or supplier", 
+    description: "A business' sellability requires that the business not be overly reliant on any one customer, employee or supplier. The name 'The Switzerland Structure' was inspired by Switzerland's focus on neutrality. The country has not declared a State of War since 1847, opted out of joining the European Union and entered the United Nations only after a countrywide referendum.",
+    insights: [
+      "Customer concentration and revenue diversification",
+      "Supplier and vendor dependencies",
+      "Key employee dependencies",
+      "Geographic and industry diversification"
+    ]
+  },
+
+  "Valuation Teeter-Totter": {
+    title: "The Valuation Teeter-Totter",
+    subtitle: "Whether your business is a cash suck or a cash spigot",
+    description: "The Valuation Teeter-Totter reflects the impact your cash flow, gross margin and profitability have on the value of your company. Imagine a playground teeter-totter that can move in only two directions: when one end goes down, the other must go up. The same is true of the value of your company as it relates to your cash flow: the more cash an acquirer must inject into your company when taking it over, the less that acquirer will pay for it.",
+    insights: [
+      "Cash flow predictability and sustainability",
+      "Working capital requirements",
+      "Days sales outstanding vs days payable outstanding",
+      "Capital intensity of the business model"
+    ]
+  },
+
+  "Recurring Revenue": {
+    title: "The Hierarchy of Recurring Revenue",
+    subtitle: "The proportion and quality of automatic, annuity-based revenue you collect each month",
+    description: "One of the biggest factors in determining the value of your company is the extent to which an acquirer can see where your sales will come from in the future. If you're in a business that must start from scratch each month, the value of your company will be lower than if you can pinpoint the source of your future revenue.",
+    insights: [
+      "Percentage of revenue that is recurring vs one-time",
+      "Contract terms and customer retention rates",
+      "Subscription model maturity",
+      "Revenue predictability and customer lifetime value"
+    ]
+  },
+
+  "Monopoly Control": {
+    title: "The Monopoly Control",
+    subtitle: "How differentiated your business is from competitors in your industry",
+    description: "Warren Buffett is famous for investing in companies with a protective 'moat' around them. The deeper and wider the moat, the harder it is for competitors to compete. In addition, an enduring competitive advantage also gives an owner more control over pricing, which increases both profitability and cash flow.",
+    insights: [
+      "Unique value proposition and differentiation",
+      "Barriers to entry in your market",
+      "Intellectual property and proprietary technology",
+      "Brand strength and customer loyalty"
+    ]
+  },
+
+  "Customer Satisfaction": {
+    title: "Customer Satisfaction",
+    subtitle: "The likelihood that your customers will repurchase and also refer you",
+    description: "This attribute measures both the extent to which your customers are satisfied and your ability to assess customer satisfaction in a consistent and rigorous way. Most business owners know intuitively how satisfied their customers are, but as their companies grow, some owners lose touch with their customers.",
+    insights: [
+      "Net Promoter Score (NPS) performance",
+      "Customer retention and repeat purchase rates",
+      "Referral rates and word-of-mouth marketing",
+      "Customer feedback systems and response mechanisms"
+    ]
+  },
+
+  "Hub & Spoke": {
+    title: "Hub and Spoke",
+    subtitle: "How your business would perform if you were unexpectedly unable to work for a period of three months",
+    description: "This factor measures the extent to which your business can thrive without you. To be valuable to an acquirer, your business must be able to succeed and grow without you at the hub of all activities, as your employees are mere spokes that cannot operate independently of you.",
+    insights: [
+      "Management team strength and autonomy",
+      "Systems and process documentation",
+      "Decision-making distribution",
+      "Organizational resilience without the owner"
+    ]
+  }
+};
+
+export const supplementalDriverDescriptions = {
+  "Financial Health & Analysis": {
+    title: "Financial Health & Analysis",
+    subtitle: "Deep financial metrics beyond basic P&L performance",
+    description: "While Financial Performance focuses on revenue and profitability, Financial Health & Analysis examines the underlying financial strength and sustainability of your business. This includes balance sheet quality, cash conversion cycles, debt management, and the sophistication of your financial planning and analysis capabilities. Strong financial health provides the foundation for weathering economic storms and funding growth opportunities.",
+    insights: [
+      "Balance sheet strength and debt-to-equity ratios",
+      "Working capital efficiency and cash conversion",
+      "Budget accuracy and financial forecasting capabilities",
+      "Quality of financial controls and reporting systems"
+    ]
+  },
+
+  "Market & Competitive Position": {
+    title: "Market & Competitive Position",
+    subtitle: "Your strategic position within the competitive landscape",
+    description: "Understanding your market position goes beyond just market share. It encompasses your competitive advantages, market dynamics, industry trends, and strategic positioning. This analysis helps identify whether you're swimming with the current or against it, and whether your market position is defensible and expandable. A strong market position indicates pricing power, customer preference, and sustainable competitive advantages.",
+    insights: [
+      "Market growth rates and industry dynamics",
+      "Competitive intensity and market share trends",
+      "Technology disruption risks and opportunities",
+      "Customer acquisition channels and their effectiveness"
+    ]
+  },
+
+  "Operational Excellence": {
+    title: "Operational Excellence",
+    subtitle: "The efficiency and scalability of your operations",
+    description: "Operational Excellence measures how well your business converts inputs into outputs. It examines your operational efficiency, quality systems, technology infrastructure, and continuous improvement culture. Businesses with strong operational excellence can scale more easily, maintain quality during growth, and often enjoy higher margins due to efficiency gains. This becomes increasingly important as businesses grow and complexity increases.",
+    insights: [
+      "Quality control systems and defect rates",
+      "Technology infrastructure and automation levels",
+      "Supply chain efficiency and inventory management",
+      "Process optimization and continuous improvement culture"
+    ]
+  },
+
+  "Human Capital & Organization": {
+    title: "Human Capital & Organization",
+    subtitle: "The strength of your team and organizational capabilities",
+    description: "Your people are often your greatest asset, and this driver examines how well you attract, develop, and retain talent. Beyond individual capabilities, it assesses your organizational culture, leadership development, succession planning, and ability to build high-performing teams. Strong human capital means your business can execute strategy effectively and adapt to changing conditions.",
+    insights: [
+      "Employee retention rates and engagement levels",
+      "Leadership depth and succession planning",
+      "Training and development programs",
+      "Organizational culture and values alignment"
+    ]
+  },
+
+  "Legal, Risk & Compliance": {
+    title: "Legal, Risk & Compliance",
+    subtitle: "Risk management and regulatory compliance framework",
+    description: "This driver examines how well your business identifies, manages, and mitigates various risks. It includes legal structure optimization, regulatory compliance, insurance coverage, contract management, and data protection. Strong performance here doesn't just prevent problems - it provides confidence to buyers that there are no hidden liabilities or compliance time bombs that could destroy value post-acquisition.",
+    insights: [
+      "Legal structure and entity optimization",
+      "Regulatory compliance across all jurisdictions",
+      "Risk management systems and insurance coverage",
+      "Contract management and intellectual property protection"
+    ]
+  },
+
+  "Strategic Assets & Intangibles": {
+    title: "Strategic Assets & Intangibles",
+    subtitle: "Unique assets and capabilities that drive competitive advantage",
+    description: "Beyond the tangible assets on your balance sheet, this driver evaluates the intangible assets that often represent the majority of a company's value. This includes brand equity, customer relationships, proprietary technology, strategic partnerships, and market position. These assets are often the hardest to replicate and can provide sustainable competitive advantages that justify premium valuations.",
+    insights: [
+      "Brand value and market recognition",
+      "Proprietary technology and innovation capabilities",
+      "Strategic partnerships and ecosystem position",
+      "Customer relationships and switching costs"
+    ]
+  }
+};
+


### PR DESCRIPTION
## Summary
- implement category descriptions for core and supplemental drivers
- include new detail page generation for each category in PDF output
- add helper function to style score colors

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686d54448674832c8f8bc206164fe954