### PR TITLE
Fix missing PDF analysis section

### DIFF
--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -75,4 +75,5 @@ export interface CategoryScore {
   score: number;
   weight: number;
   maxScore: number;
+  analysis?: string;
 }


### PR DESCRIPTION
## Summary
- allow CategoryScore to store AI analysis
- add fallback analysis generation on error
- fetch AI analysis when drawing category sections in PDF
- render analysis paragraphs with pagination

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686e7875711c832cb925f4d5a689dbc3