### PR TITLE
Add HTML report preview step

### DIFF
--- a/client/src/components/assessment/ReportPreview.tsx
+++ b/client/src/components/assessment/ReportPreview.tsx
@@ -1,0 +1,77 @@
+import { useQuery } from "@tanstack/react-query";
+import { apiRequest } from "@/lib/queryClient";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent } from "@/components/ui/card";
+
+interface ReportPreviewProps {
+  sessionId: string;
+  userName?: string;
+  companyName?: string;
+  industry?: string;
+  onSendEmail: () => void;
+}
+
+export default function ReportPreview({
+  sessionId,
+  userName,
+  companyName,
+  industry,
+  onSendEmail,
+}: ReportPreviewProps) {
+  const queryKey = [
+    "reportPreview",
+    sessionId,
+    userName,
+    companyName,
+    industry,
+  ];
+
+  const { data, isLoading } = useQuery({
+    queryKey,
+    queryFn: async () => {
+      const params = new URLSearchParams();
+      if (userName) params.append("userName", userName);
+      if (companyName) params.append("companyName", companyName);
+      if (industry) params.append("industry", industry);
+      const res = await apiRequest(
+        "GET",
+        `/api/reports/preview/${sessionId}?${params.toString()}`
+      );
+      return res.text();
+    },
+  });
+
+  const handleExportPdf = () => {
+    const params = new URLSearchParams();
+    if (userName) params.append("userName", userName);
+    if (companyName) params.append("companyName", companyName);
+    if (industry) params.append("industry", industry);
+    window.open(
+      `/api/reports/export/pdf/${sessionId}?${params.toString()}`,
+      "_blank"
+    );
+  };
+
+  return (
+    <div className="space-y-4">
+      <Card className="shadow-sm">
+        <CardContent className="p-0">
+          {isLoading ? (
+            <div className="p-6 text-center">Generating preview...</div>
+          ) : (
+            <div
+              className="p-6 max-h-[70vh] overflow-auto"
+              dangerouslySetInnerHTML={{ __html: data || "" }}
+            />
+          )}
+        </CardContent>
+      </Card>
+      <div className="flex justify-end space-x-2">
+        <Button onClick={onSendEmail}>Send Report via Email</Button>
+        <Button variant="outline" onClick={handleExportPdf}>
+          Export as PDF
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/client/src/components/assessment/ResultsScreen.tsx
+++ b/client/src/components/assessment/ResultsScreen.tsx
@@ -1,7 +1,13 @@
 import { useState } from "react";
 import { useMutation } from "@tanstack/react-query";
-import { AssessmentAnswer, CategoryScore } from "@shared/schema";
-import { calculateCategoryScores, calculateOverallScore, getScoreGrade, getScoreColor, getScoreBarColor } from "@/lib/scoring";
+import { AssessmentAnswer } from "@shared/schema";
+import {
+  calculateCategoryScores,
+  calculateOverallScore,
+  getScoreGrade,
+  getScoreColor,
+  getScoreBarColor,
+} from "@/lib/scoring";
 import { apiRequest } from "@/lib/queryClient";
 import { useToast } from "@/hooks/use-toast";
 import { Button } from "@/components/ui/button";
@@ -10,6 +16,7 @@ import { Input } from "@/components/ui/input";
 import { Label } from "@/components/ui/label";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "@/components/ui/select";
 import { CheckCircle, Send, ChartLine, Users, Cog, UserCheck, Shield, Gem, TrendingUp, Target } from "lucide-react";
+import ReportPreview from "./ReportPreview";
 
 interface ResultsScreenProps {
   answers: Record<string, AssessmentAnswer>;
@@ -25,6 +32,8 @@ export default function ResultsScreen({ answers, sessionId }: ResultsScreenProps
   });
   const [isSubmitted, setIsSubmitted] = useState(false);
   const { toast } = useToast();
+
+  const [view, setView] = useState<"summary" | "preview" | "email">("summary");
 
   // Calculate scores
   const categoryScores = calculateCategoryScores(answers);
@@ -42,14 +51,12 @@ export default function ResultsScreen({ answers, sessionId }: ResultsScreenProps
       if (data.emailStatus === "success") {
         toast({
           title: "Results sent successfully!",
-          description:
-            "Your assessment report has been sent to your email and our team.",
+          description: "Your assessment report has been sent to your email and our team.",
         });
       } else {
         toast({
           title: "Email failed to send",
-          description:
-            "Your results were saved, but the email could not be delivered.",
+          description: "Your results were saved, but the email could not be delivered.",
           variant: "destructive",
         });
       }
@@ -65,7 +72,7 @@ export default function ResultsScreen({ answers, sessionId }: ResultsScreenProps
 
   const handleSubmit = (e: React.FormEvent) => {
     e.preventDefault();
-    
+
     if (!userInfo.name || !userInfo.email) {
       toast({
         title: "Missing information",
@@ -129,134 +136,145 @@ export default function ResultsScreen({ answers, sessionId }: ResultsScreenProps
     "Strategic Assets & Intangibles",
   ];
 
-  const strongAreas = Object.values(categoryScores).filter(score => score.score >= 80).length;
-  const priorityAreas = Object.values(categoryScores).filter(score => score.score < 60).length;
+  const strongAreas = Object.values(categoryScores).filter((score) => score.score >= 80).length;
+  const priorityAreas = Object.values(categoryScores).filter((score) => score.score < 60).length;
 
   return (
     <div className="space-y-6">
-      {/* Results Header */}
-      <Card className="shadow-sm">
-        <CardContent className="pt-8 text-center">
-          <div className="w-16 h-16 bg-green-500 rounded-full flex items-center justify-center mx-auto mb-4">
-            <CheckCircle className="w-8 h-8 text-white" />
-          </div>
-          <h2 className="text-3xl font-bold text-gray-900 mb-2">Assessment Complete!</h2>
-          <p className="text-lg text-gray-600 mb-6">Your comprehensive business valuation analysis is ready</p>
-          
-          {/* Overall Score */}
-          <div className="inline-block bg-gray-50 rounded-lg p-6 mb-6">
-            <div className={`text-4xl font-bold mb-2 ${getScoreColor(overallScore)}`}>
-              {overallScore}
-            </div>
-            <div className="text-sm text-gray-600">Overall Value Builder Score</div>
-            <div className="text-xs text-gray-500 mt-1">Out of 100 points</div>
-          </div>
+      {view === "summary" && (
+        <>
+          {/* Results Header */}
+          <Card className="shadow-sm">
+            <CardContent className="pt-8 text-center">
+              <div className="w-16 h-16 bg-green-500 rounded-full flex items-center justify-center mx-auto mb-4">
+                <CheckCircle className="w-8 h-8 text-white" />
+              </div>
+              <h2 className="text-3xl font-bold text-gray-900 mb-2">Assessment Complete!</h2>
+              <p className="text-lg text-gray-600 mb-6">Your comprehensive business valuation analysis is ready</p>
 
-          {/* Quick Stats */}
-          <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
-            <div className="bg-gray-50 rounded-lg p-4">
-              <div className="text-xl font-semibold text-gray-900">{grade}</div>
-              <div className="text-sm text-gray-600">Overall Grade</div>
-            </div>
-            <div className="bg-gray-50 rounded-lg p-4">
-              <div className="text-xl font-semibold text-gray-900">{strongAreas}/14</div>
-              <div className="text-sm text-gray-600">Strong Areas</div>
-            </div>
-            <div className="bg-gray-50 rounded-lg p-4">
-              <div className="text-xl font-semibold text-gray-900">{priorityAreas}</div>
-              <div className="text-sm text-gray-600">Priority Areas</div>
-            </div>
-            <div className="bg-gray-50 rounded-lg p-4">
-              <div className="text-xl font-semibold text-gray-900">Est.</div>
-              <div className="text-sm text-gray-600">Valuation</div>
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+              {/* Overall Score */}
+              <div className="inline-block bg-gray-50 rounded-lg p-6 mb-6">
+                <div className={`text-4xl font-bold mb-2 ${getScoreColor(overallScore)}`}>{overallScore}</div>
+                <div className="text-sm text-gray-600">Overall Value Builder Score</div>
+                <div className="text-xs text-gray-500 mt-1">Out of 100 points</div>
+              </div>
 
-      {/* Category Breakdown */}
-      <Card className="shadow-sm">
-        <CardContent className="pt-8">
-          <h3 className="text-xl font-semibold text-gray-900 mb-6">Detailed Category Breakdown</h3>
-          
-          {/* Core Drivers */}
-          <div className="mb-8">
-            <h4 className="text-lg font-medium text-gray-900 mb-4">Part I: Core Value Builder Drivers (70% weight)</h4>
-            <div className="space-y-4">
-              {coreDrivers.map((driver) => {
-                const score = categoryScores[driver];
-                if (!score) return null;
-                
-                const Icon = getCategoryIcon(driver);
-                return (
-                  <div key={driver} className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
-                    <div className="flex items-center">
-                      <div className={`w-8 h-8 rounded-full flex items-center justify-center mr-3 ${getScoreBarColor(score.score)}`}>
-                        <Icon className="w-4 h-4 text-white" />
-                      </div>
-                      <div>
-                        <span className="font-medium text-gray-900">{driver}</span>
-                        <span className="text-sm text-gray-600 ml-2">({Math.round(score.weight * 100)}% weight)</span>
-                      </div>
-                    </div>
-                    <div className="flex items-center">
-                      <div className="w-24 bg-gray-200 rounded-full h-2 mr-3">
-                        <div 
-                          className={`h-2 rounded-full ${getScoreBarColor(score.score)}`}
-                          style={{ width: `${score.score}%` }}
-                        />
-                      </div>
-                      <span className="font-semibold text-gray-900 w-8">{score.score}</span>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
+              {/* Quick Stats */}
+              <div className="grid grid-cols-2 md:grid-cols-4 gap-4 mb-6">
+                <div className="bg-gray-50 rounded-lg p-4">
+                  <div className="text-xl font-semibold text-gray-900">{grade}</div>
+                  <div className="text-sm text-gray-600">Overall Grade</div>
+                </div>
+                <div className="bg-gray-50 rounded-lg p-4">
+                  <div className="text-xl font-semibold text-gray-900">{strongAreas}/14</div>
+                  <div className="text-sm text-gray-600">Strong Areas</div>
+                </div>
+                <div className="bg-gray-50 rounded-lg p-4">
+                  <div className="text-xl font-semibold text-gray-900">{priorityAreas}</div>
+                  <div className="text-sm text-gray-600">Priority Areas</div>
+                </div>
+                <div className="bg-gray-50 rounded-lg p-4">
+                  <div className="text-xl font-semibold text-gray-900">Est.</div>
+                  <div className="text-sm text-gray-600">Valuation</div>
+                </div>
+              </div>
+            </CardContent>
+          </Card>
 
-          {/* Supplemental Analysis */}
-          <div>
-            <h4 className="text-lg font-medium text-gray-900 mb-4">Part II: Supplemental Deep-Dive Analysis (30% weight)</h4>
-            <div className="space-y-4">
-              {supplementalDrivers.map((driver) => {
-                const score = categoryScores[driver];
-                if (!score) return null;
-                
-                const Icon = getCategoryIcon(driver);
-                return (
-                  <div key={driver} className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
-                    <div className="flex items-center">
-                      <div className={`w-8 h-8 rounded-full flex items-center justify-center mr-3 ${getScoreBarColor(score.score)}`}>
-                        <Icon className="w-4 h-4 text-white" />
-                      </div>
-                      <span className="font-medium text-gray-900">{driver}</span>
-                    </div>
-                    <div className="flex items-center">
-                      <div className="w-24 bg-gray-200 rounded-full h-2 mr-3">
-                        <div 
-                          className={`h-2 rounded-full ${getScoreBarColor(score.score)}`}
-                          style={{ width: `${score.score}%` }}
-                        />
-                      </div>
-                      <span className="font-semibold text-gray-900 w-8">{score.score}</span>
-                    </div>
-                  </div>
-                );
-              })}
-            </div>
-          </div>
-        </CardContent>
-      </Card>
+          {/* Category Breakdown */}
+          <Card className="shadow-sm">
+            <CardContent className="pt-8">
+              <h3 className="text-xl font-semibold text-gray-900 mb-6">Detailed Category Breakdown</h3>
 
-      {/* Email Capture */}
-      {!isSubmitted && (
+              {/* Core Drivers */}
+              <div className="mb-8">
+                <h4 className="text-lg font-medium text-gray-900 mb-4">Part I: Core Value Builder Drivers (70% weight)</h4>
+                <div className="space-y-4">
+                  {coreDrivers.map((driver) => {
+                    const score = categoryScores[driver];
+                    if (!score) return null;
+
+                    const Icon = getCategoryIcon(driver);
+                    return (
+                      <div key={driver} className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+                        <div className="flex items-center">
+                          <div className={`w-8 h-8 rounded-full flex items-center justify-center mr-3 ${getScoreBarColor(score.score)}`}
+                          >
+                            <Icon className="w-4 h-4 text-white" />
+                          </div>
+                          <div>
+                            <span className="font-medium text-gray-900">{driver}</span>
+                            <span className="text-sm text-gray-600 ml-2">({Math.round(score.weight * 100)}% weight)</span>
+                          </div>
+                        </div>
+                        <div className="flex items-center">
+                          <div className="w-24 bg-gray-200 rounded-full h-2 mr-3">
+                            <div className={`h-2 rounded-full ${getScoreBarColor(score.score)}`} style={{ width: `${score.score}%` }} />
+                          </div>
+                          <span className="font-semibold text-gray-900 w-8">{score.score}</span>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+
+              {/* Supplemental Analysis */}
+              <div>
+                <h4 className="text-lg font-medium text-gray-900 mb-4">Part II: Supplemental Deep-Dive Analysis (30% weight)</h4>
+                <div className="space-y-4">
+                  {supplementalDrivers.map((driver) => {
+                    const score = categoryScores[driver];
+                    if (!score) return null;
+
+                    const Icon = getCategoryIcon(driver);
+                    return (
+                      <div key={driver} className="flex items-center justify-between p-4 bg-gray-50 rounded-lg">
+                        <div className="flex items-center">
+                          <div className={`w-8 h-8 rounded-full flex items-center justify-center mr-3 ${getScoreBarColor(score.score)}`}
+                          >
+                            <Icon className="w-4 h-4 text-white" />
+                          </div>
+                          <span className="font-medium text-gray-900">{driver}</span>
+                        </div>
+                        <div className="flex items-center">
+                          <div className="w-24 bg-gray-200 rounded-full h-2 mr-3">
+                            <div className={`h-2 rounded-full ${getScoreBarColor(score.score)}`} style={{ width: `${score.score}%` }} />
+                          </div>
+                          <span className="font-semibold text-gray-900 w-8">{score.score}</span>
+                        </div>
+                      </div>
+                    );
+                  })}
+                </div>
+              </div>
+            </CardContent>
+          </Card>
+
+          <div className="text-right">
+            <Button onClick={() => setView("preview")}>View Full Report</Button>
+          </div>
+        </>
+      )}
+
+      {view === "preview" && (
+        <ReportPreview
+          sessionId={sessionId}
+          userName={userInfo.name}
+          companyName={userInfo.company}
+          industry={userInfo.industry}
+          onSendEmail={() => setView("email")}
+        />
+      )}
+
+      {view === "email" && !isSubmitted && (
         <Card className="shadow-sm">
           <CardContent className="pt-8">
             <h3 className="text-xl font-semibold text-gray-900 mb-4">Get Your Detailed Report</h3>
             <p className="text-gray-600 mb-6">
               Enter your information to receive your comprehensive Value Builder Assessment report with detailed analysis and actionable recommendations.
             </p>
-            
+
             <form onSubmit={handleSubmit} className="space-y-4">
               <div className="grid md:grid-cols-2 gap-4">
                 <div>
@@ -317,8 +335,8 @@ export default function ResultsScreen({ answers, sessionId }: ResultsScreenProps
                   </SelectContent>
                 </Select>
               </div>
-              <Button 
-                type="submit" 
+              <Button
+                type="submit"
                 className="w-full bg-primary hover:bg-blue-700"
                 disabled={submitResultsMutation.isPending}
               >
@@ -330,7 +348,6 @@ export default function ResultsScreen({ answers, sessionId }: ResultsScreenProps
         </Card>
       )}
 
-      {/* Success Message */}
       {isSubmitted && (
         <Card className="shadow-sm bg-green-50 border-green-200">
           <CardContent className="pt-6 text-center">


### PR DESCRIPTION
## Summary
- add new `ReportPreview` component for fetching HTML report
- insert preview step into `ResultsScreen`
- allow exporting PDF and sending report from preview page

## Testing
- `npm install`
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686eac28c5e0832cb4a3d4178a6828ba