### PR TITLE
Improve HTML report and clean PDF generator

### DIFF
--- a/server/htmlReportGenerator.ts
+++ b/server/htmlReportGenerator.ts
@@ -1,22 +1,79 @@
+import { CategoryScore } from '@shared/schema';
+import { coreDrivers, supplementalDrivers } from './pdfGenerator';
+import {
+  coreDriverDescriptions,
+  supplementalDriverDescriptions
+} from './reportTemplates';
+
 export interface HtmlReportOptions {
   userName: string;
   companyName?: string;
   industry?: string;
   overallScore: number;
-  categoryScores: Record<string, { score: number }>;
+  categoryScores: Record<string, CategoryScore>;
   aiInsights?: string;
 }
 
 export async function generateHTMLReport(options: HtmlReportOptions): Promise<string> {
   const { userName, companyName, industry, overallScore, categoryScores, aiInsights } = options;
 
-  const rows = Object.entries(categoryScores)
-    .map(([name, s]) => `<tr><td>${name}</td><td class="score">${s.score}</td></tr>`) 
-    .join("\n");
+  const grade = getGrade(overallScore);
+
+  const coreRows = coreDrivers
+    .map((d) => {
+      const s = categoryScores[d];
+      if (!s) return '';
+      return `<tr><td>${d}</td><td class="score">${s.score}</td></tr>`;
+    })
+    .join('\n');
+
+  const supplementalRows = supplementalDrivers
+    .map((d) => {
+      const s = categoryScores[d];
+      if (!s) return '';
+      return `<tr><td>${d}</td><td class="score">${s.score}</td></tr>`;
+    })
+    .join('\n');
 
   const insightsSection = aiInsights
-    ? `<h2>Executive Analysis</h2><p>${aiInsights.replace(/\n/g, '<br/>')}</p>`
+    ? `<h2>Executive Analysis &amp; Strategic Insights</h2><p>${aiInsights.replace(/\n/g, '<br/>')}</p>`
     : '';
+
+  const improvementList = Object.entries(categoryScores)
+    .filter(([_, s]) => s.score < 60)
+    .sort((a, b) => a[1].score - b[1].score)
+    .map(([cat, s]) => {
+      const rec = getImprovementRecommendation(cat, s.score);
+      return `<li><strong>${cat} (${s.score}/100)</strong> - ${rec}</li>`;
+    })
+    .join('\n');
+
+  const detailSections = [
+    ...coreDrivers,
+    ...supplementalDrivers
+  ]
+    .filter((cat) => categoryScores[cat])
+    .map((cat) => {
+      const s = categoryScores[cat];
+      const details =
+        (coreDriverDescriptions as Record<string, any>)[cat] ||
+        (supplementalDriverDescriptions as Record<string, any>)[cat];
+      if (!details) return '';
+      const analysis = s.analysis ? `<p><em>${s.analysis.replace(/\n/g, '<br/>')}</em></p>` : '';
+      return `
+        <section>
+          <h3>${details.title} - ${s.score}/100</h3>
+          <p><strong>${details.subtitle}</strong></p>
+          <p>${details.description}</p>
+          <h4>Key Assessment Areas:</h4>
+          <ul>${details.insights.map((i: string) => `<li>${i}</li>`).join('')}</ul>
+          <h4>Improvement Opportunities:</h4>
+          <p>${getImprovementRecommendation(cat, s.score)}</p>
+          ${analysis}
+        </section>
+      `;
+    })
+    .join('\n');
 
   return `<!DOCTYPE html>
 <html>
@@ -25,11 +82,12 @@ export async function generateHTMLReport(options: HtmlReportOptions): Promise<st
   <title>Value Builder Assessment Report</title>
   <style>
     body { font-family: Arial, sans-serif; margin: 40px; }
-    h1, h2 { color: #1e40af; }
+    h1, h2, h3, h4 { color: #1e40af; }
     table { width: 100%; border-collapse: collapse; margin-top: 20px; }
     th, td { border: 1px solid #ddd; padding: 8px; }
     th { background-color: #f3f4f6; text-align: left; }
     .score { text-align: right; }
+    section { margin-top: 40px; }
   </style>
 </head>
 <body>
@@ -37,12 +95,66 @@ export async function generateHTMLReport(options: HtmlReportOptions): Promise<st
   <p><strong>User:</strong> ${userName}</p>
   ${companyName ? `<p><strong>Company:</strong> ${companyName}</p>` : ''}
   ${industry ? `<p><strong>Industry:</strong> ${industry}</p>` : ''}
-  <h2>Overall Score: ${overallScore}/100</h2>
+  <p><strong>Date:</strong> ${new Date().toLocaleDateString()}</p>
+  <h2>Overall Score: ${overallScore}/100 (Grade: ${grade})</h2>
+  ${insightsSection}
+
+  <h2>Performance Summary</h2>
+  <h3>Part I: Core Value Builder Drivers</h3>
   <table>
     <tr><th>Category</th><th>Score</th></tr>
-    ${rows}
+    ${coreRows}
   </table>
-  ${insightsSection}
+  <h3>Part II: Supplemental Deep-Dive Analysis</h3>
+  <table>
+    <tr><th>Category</th><th>Score</th></tr>
+    ${supplementalRows}
+  </table>
+
+  ${improvementList ? `<h2>Priority Areas for Improvement</h2><ul>${improvementList}</ul>` : ''}
+
+  ${detailSections}
 </body>
 </html>`;
+}
+
+function getGrade(score: number): string {
+  if (score >= 90) return 'A+';
+  if (score >= 80) return 'A';
+  if (score >= 70) return 'B';
+  if (score >= 60) return 'C';
+  if (score >= 50) return 'D';
+  return 'F';
+}
+
+function getImprovementRecommendation(category: string, score: number): string {
+  const recommendations: Record<string, string> = {
+    'Financial Performance':
+      'Consider implementing stronger financial controls, improving profit margins, and establishing more predictable revenue streams.',
+    'Growth Potential':
+      'Focus on market expansion strategies, product innovation, and developing scalable business processes.',
+    'Switzerland Structure':
+      'Work on reducing dependencies on key customers, suppliers, or employees. Diversify your risk.',
+    'Valuation Teeter-Totter':
+      'Strengthen your competitive position and build sustainable advantages in your market.',
+    'Recurring Revenue':
+      'Develop subscription models, long-term contracts, or membership programs to increase predictable revenue.',
+    'Monopoly Control':
+      'Build stronger barriers to entry, protect intellectual property, and increase pricing power.',
+    'Customer Satisfaction': 'Implement customer feedback systems, improve service quality, and track NPS scores.',
+    'Hub & Spoke':
+      'Reduce owner dependence by building strong management teams and documenting all processes.',
+    'Financial Health & Analysis':
+      'Strengthen balance sheet, improve cash flow management, and enhance financial reporting.',
+    'Market & Competitive Position':
+      'Analyze competitive landscape, identify market opportunities, and strengthen positioning.',
+    'Operational Excellence':
+      'Optimize processes, implement quality systems, and improve operational efficiency.',
+    'Human Capital & Organization':
+      'Invest in employee development, improve retention, and build strong organizational culture.',
+    'Legal, Risk & Compliance': 'Review legal structures, enhance compliance systems, and mitigate business risks.',
+    'Strategic Assets & Intangibles': 'Protect and leverage intellectual property, brand value, and strategic relationships.'
+  };
+
+  return recommendations[category] || 'Focus on systematic improvements in this area to increase business value.';
 }

--- a/server/pdfGenerator.ts
+++ b/server/pdfGenerator.ts
@@ -393,64 +393,6 @@ function drawCategoryBar(
   return ROW_HEIGHT + 10;
 }
 
-function generateCategoryDetailPage(
-  doc: PDFKit.PDFDocument,
-  category: string,
-  score: CategoryScore,
-  isCore: boolean
-) {
-  doc.addPage();
-  const descriptions = isCore ? coreDriverDescriptions : supplementalDriverDescriptions;
-  const details = (descriptions as Record<string, any>)[category];
-
-  if (!details) return;
-
-  drawScoreGauge(doc, 350, 50, score.score);
-
-  doc.fontSize(24).fillColor('#1e40af').text(details.title, 50, 50, { width: 280 });
-
-  doc.fontSize(12).fillColor('#6b7280').text(details.subtitle, 50, 80, { width: 280, lineGap: 3 });
-
-  doc.fontSize(48).fillColor(getScoreColor(score.score)).text(`${score.score}`, 50, 120, {
-    width: 100,
-    align: 'center'
-  });
-  doc.fontSize(16).fillColor('#6b7280').text('/100', 150, 135);
-
-  doc
-    .fontSize(11)
-    .fillColor('#111827')
-    .text(details.description, 50, 200, {
-      width: 500,
-      align: 'justify',
-      lineGap: 4
-    });
-
-  let currentY = doc.y + 20;
-  doc.fontSize(14).fillColor('#1e40af').text('Key Assessment Areas:', 50, currentY);
-
-  currentY += 20;
-  details.insights.forEach((insight: string) => {
-    doc.fontSize(10).fillColor('#374151').text(`• ${insight}`, 70, currentY, {
-      width: 480,
-      lineGap: 3
-    });
-    currentY = doc.y + 8;
-  });
-
-  if (score.score < 60) {
-    currentY += 15;
-    doc.fontSize(14).fillColor('#dc2626').text('Improvement Opportunities:', 50, currentY);
-
-    currentY += 15;
-    const recommendations = getImprovementRecommendation(category, score.score);
-    doc.fontSize(10).fillColor('#374151').text(recommendations, 50, currentY, {
-      width: 500,
-      align: 'justify',
-      lineGap: 4
-    });
-  }
-}
 
 async function drawCategoryDetail(
   doc: PDFKit.PDFDocument,
@@ -779,44 +721,11 @@ function getImprovementRecommendation(category: string, score: number): string {
   return recommendations[category] || 'Focus on systematic improvements in this area to increase business value.';
 }
 
-function getStrategicRecommendations(
-  overallScore: number,
-  categoryScores: Record<string, CategoryScore>
-): string[] {
-  const items: string[] = [];
-
-  if (overallScore < 60) {
-    items.push('Your business has significant opportunities for value improvement. Focus on the lowest-scoring areas first.');
-    items.push('Consider engaging a business advisor to help develop a comprehensive improvement plan.');
-  } else if (overallScore < 80) {
-    items.push('Your business shows good potential. Targeted improvements in key areas can significantly increase value.');
-    items.push('Prioritize 2-3 improvement areas and develop 90-day action plans for each.');
-  } else {
-    items.push('Your business is performing well. Focus on maintaining strengths while addressing any remaining gaps.');
-    items.push('Consider strategic initiatives to move from good to exceptional in your strongest areas.');
-  }
-
-  const recurringRevScore = categoryScores['Recurring Revenue']?.score || 0;
-  if (recurringRevScore < 60) {
-    items.push('Urgently develop recurring revenue streams to improve business predictability and value.');
-  }
-
-  const hubSpokeScore = categoryScores['Hub & Spoke']?.score || 0;
-  if (hubSpokeScore < 60) {
-    items.push('Reduce owner dependence by developing management systems and key employee capabilities.');
-  }
-
-  return items;
-}
 
 function getScoreColor(score: number): string {
   if (score >= 80) return '#10b981';
   if (score >= 45) return '#f59e0b';
   return '#ef4444';
-}
-
-function getScoreBarColor(score: number): string {
-  return getScoreColor(score);
 }
 
 

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -189,16 +189,15 @@ export async function registerRoutes(app: Express): Promise<Server> {
         req.query.industry as string | undefined
       );
 
-      const html = await generateHTMLReport({
-        userName: (req.query.userName as string) || "User",
-        companyName: req.query.companyName as string | undefined,
-        industry: req.query.industry as string | undefined,
-        overallScore: overall,
-        categoryScores: assessment.categoryScores,
-        aiInsights: insights,
-      });
-
-      const pdf = await htmlToPdfBuffer(html);
+      const pdf = await generatePDFReport(
+        (req.query.userName as string) || "User",
+        (req.query.userEmail as string) || "",
+        req.query.companyName as string || "",
+        req.query.industry as string || "",
+        overall,
+        assessment.categoryScores,
+        assessment.answers as Record<string, AssessmentAnswer>
+      );
       res.setHeader("Content-Type", "application/pdf");
       res.send(pdf);
     } catch (error) {


### PR DESCRIPTION
## Summary
- extend `htmlReportGenerator` to mirror PDF content with category details
- clean up `pdfGenerator` by removing unused helper functions
- adjust export route to use `generatePDFReport`

## Testing
- `npm run check`

------
https://chatgpt.com/codex/tasks/task_e_686eb11da2c8832cbd23055034e628a5